### PR TITLE
feat: create home and chat pages on activation

### DIFF
--- a/aztra-g-fall-animal/README.md
+++ b/aztra-g-fall-animal/README.md
@@ -1,0 +1,29 @@
+# Aztra G Fall Animal
+
+WordPress plugin providing an interface to build and chat with Animal Flight models. The plugin registers several shortcodes:
+
+- `[aztra_home]` – landing page with a sample JSON preview and button to save your webhook before starting a conversation.
+- `[aztra_builder]` – form to configure model parameters and send them to the workflow.
+- `[aztra_chat]` – two-column chat interface supporting file uploads.
+- `[aztra_gallery]` – list of saved responses for the current user.
+- `[aztra_login]` and `[aztra_signup]` – basic authentication pages.
+
+## Setup
+
+1. Upload the plugin to your WordPress installation and activate it. Activation creates the pages **Aztra — Home**, **Chat**, **App**, **Gallery**, **Login** and **Signup**.
+2. On first visit, go to **Aztra — Home** to preview the webhook response.
+3. Use **Salvar Modelo e iniciar conversa** to store your production webhook and open the chat.
+
+The theme toggle works across all pages and your last generated response is kept in `localStorage` to be previewed on the home screen.
+
+## Development
+
+Source code lives in the `aztra-g-fall-animal` directory. Assets are in `assets/`. PHP lint can be run with:
+
+```bash
+php -l aztra-g-fall-animal.php
+php -l includes/class-aztra-shortcodes.php
+```
+
+---
+This repository is intended for experimentation with the Aztra G console and is not an official release.

--- a/aztra-g-fall-animal/assets/app.css
+++ b/aztra-g-fall-animal/assets/app.css
@@ -1,0 +1,38 @@
+:root{
+  --az-bg:#f7f8fb;
+  --az-text:#0f172a;
+  --az-card-bg:#ffffff;
+  --az-card-color:#0f172a;
+  --az-input-bg:#f4f6fb;
+  --az-input-bd:#dfe6f0;
+  --az-btn-bg:linear-gradient(135deg,#2563eb,#7c3aed);
+  --az-gap:16px;
+}
+.az-theme-dark{
+  --az-bg:#0e1116;
+  --az-text:#e8edff;
+  --az-card-bg:#141925;
+  --az-card-color:#e8edff;
+  --az-input-bg:#0b0f18;
+  --az-input-bd:#263041;
+  --az-btn-bg:linear-gradient(135deg,#7c3aed,#06b6d4);
+}
+body{background:var(--az-bg);color:var(--az-text);font-family:Inter,system-ui,sans-serif;}
+.az-header,.az-footer{padding:var(--az-gap);}
+.az-header{display:flex;justify-content:space-between;align-items:center;}
+.az-nav{display:flex;gap:8px;}
+.az-home{text-align:center;padding:var(--az-gap);}
+.az-chat-layout{display:grid;grid-template-columns:200px 1fr;gap:var(--az-gap);}
+.az-sidebar{display:flex;flex-direction:column;gap:8px;}
+.az-chat-log{border:1px solid var(--az-input-bd);min-height:200px;padding:var(--az-gap);margin-bottom:var(--az-gap);overflow:auto;}
+.az-btn{background:#2b34ff;color:#fff;border:none;border-radius:10px;padding:10px 14px;cursor:pointer;}
+.az-btn.az-primary{background:var(--az-btn-bg);}
+.az-field{display:flex;flex-direction:column;gap:6px;margin-bottom:10px;}
+.az-field input,.az-field select,.az-field textarea{background:var(--az-input-bg);color:var(--az-text);border:1px solid var(--az-input-bd);border-radius:10px;padding:10px;}
+.az-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1000;}
+.az-modal{background:var(--az-card-bg);color:var(--az-card-color);padding:var(--az-gap);border-radius:12px;max-width:400px;width:100%;}
+.az-row{display:flex;gap:8px;justify-content:flex-end;margin-top:var(--az-gap);}
+.az-card{background:var(--az-card-bg);color:var(--az-card-color);border-radius:16px;padding:20px;box-shadow:0 10px 30px rgba(0,0,0,.12);}
+.az-assets{display:flex;flex-wrap:wrap;gap:12px;}
+.az-thumb{max-width:100%;height:auto;border-radius:12px;border:1px solid var(--az-input-bd);box-shadow:0 4px 16px rgba(0,0,0,.25);}
+pre{background:var(--az-input-bg);color:var(--az-text);padding:12px;border-radius:10px;max-height:280px;overflow:auto;}

--- a/aztra-g-fall-animal/assets/app.js
+++ b/aztra-g-fall-animal/assets/app.js
@@ -1,0 +1,122 @@
+(function(){
+  const api = (path, init={}) => {
+    const url = new URL(path, AZTRA_CFG.rest);
+    url.searchParams.set('_wpnonce', AZTRA_CFG.nonce);
+    return fetch(url, init).then(r=>r.json());
+  };
+  const qs = (s,el=document)=>el.querySelector(s);
+
+  const setTheme = (mode)=>{
+    document.body.classList.toggle('az-theme-dark', mode==='dark');
+    localStorage.setItem('aztra_theme', mode);
+  };
+  const toggleTheme = ()=>setTheme(document.body.classList.contains('az-theme-dark')?'light':'dark');
+  setTheme(localStorage.getItem('aztra_theme')||'light');
+
+  const previewEl = qs('#aztra-preview');
+  if(previewEl){
+    const storedPreview = localStorage.getItem('aztra_preview');
+    if(storedPreview) previewEl.textContent = storedPreview;
+  }
+
+  document.addEventListener('click', async (e)=>{
+    const el = e.target.closest('[data-aztra-act]');
+    if(!el) return;
+    const act = el.dataset.aztraAct;
+
+    if(act==='signup'){
+      const u = qs('#az-su-user')?.value.trim();
+      const p = qs('#az-su-pass')?.value;
+      const c = qs('#az-su-code')?.value.trim();
+      if(!u||!p||!c){ alert('Fill all fields'); return; }
+      const res = await api('/signup', {method:'POST', body: new URLSearchParams({username:u,password:p,code:c})});
+      if(res?.ok){ alert('Account created. Please login.'); const url = document.querySelector('[data-aztra-login-url]')?.dataset.aztraLoginUrl || '/'; window.location.href = url; }
+      else alert((res?.message)||'Signup failed');
+    }
+
+    if(act==='generate'){
+      const form = qs('#aztra-form');
+      const f = Object.fromEntries(new FormData(form).entries());
+      const res = await api('/generate', {method:'POST', body: new URLSearchParams(f)});
+      if(!res?.ok){ alert('Send failed'); return; }
+      renderResponse(res.data);
+    }
+
+    if(act==='toggle-theme') toggleTheme();
+
+    if(act==='open-save-model') openWebhookModal();
+
+    if(act==='close-modal') qs('.az-overlay')?.remove();
+
+    if(act==='save-webhook'){
+      const url = qs('#aztra-webhook')?.value.trim();
+      if(url) localStorage.setItem('aztra_webhook', url);
+      window.location.href = AZTRA_CFG.chat_url || '/';
+    }
+  });
+
+  async function loadLists(){
+    const wrap = qs('#aztra-form'); if(!wrap) return;
+    const lists = await api('/lists');
+    const fill = (id, arr)=>{ const s=qs('#'+id); if(s) s.innerHTML = arr.map(v=>`<option>${v}</option>`).join(''); };
+    fill('animal',lists.animals); fill('scenario',lists.scenarios);
+    fill('time_of_day',lists.time_of_day); fill('weather',lists.weather);
+    fill('flight_style',lists.flight_style); fill('camera_movement',lists.camera_movement);
+    fill('style',lists.style);
+  }
+  loadLists();
+
+  function renderResponse(data){
+    const formatted = JSON.stringify(data, null, 2);
+    const box = qs('#aztra-response'); if(box) box.textContent = formatted;
+    localStorage.setItem('aztra_preview', formatted);
+    const assets = qs('#aztra-assets'); if(!assets) return;
+    assets.innerHTML = '';
+    const addAsset = (h)=>{ const d=document.createElement('div'); d.className='az-asset'; d.innerHTML=h; assets.appendChild(d); };
+
+    if(data?.binary){
+      Object.entries(data.binary).forEach(([k,bin])=>{
+        if(bin?.data){
+          const url = toBlobUrl(bin.data, bin.mimeType||'application/octet-stream');
+          if((bin.mimeType||'').startsWith('image/')) addAsset(`<img src="${url}" class="az-thumb" alt="${bin.fileName||k}"><details><summary>Base64</summary><textarea>${bin.data}</textarea></details>`);
+          else if((bin.mimeType||'').startsWith('video/')) addAsset(`<video controls class="az-thumb" src="${url}"></video><details><summary>Base64</summary><textarea>${bin.data}</textarea></details>`);
+          else addAsset(`<a class="az-btn" download="${bin.fileName||k}" href="${url}">Download ${bin.fileName||k}</a><details><summary>Base64</summary><textarea>${bin.data}</textarea></details>`);
+        }
+      });
+    }
+    if(data?.data && Array.isArray(data.data) && data.data[0]?.b64_json){
+      const b64 = data.data[0].b64_json;
+      const url = toBlobUrl(b64,'image/png');
+      addAsset(`<img src="${url}" class="az-thumb" alt="image"><details><summary>Base64</summary><textarea>${b64}</textarea></details>`);
+    }
+    const link = data.webViewLink || data.webContentLink || data.link || data.url;
+    if(link){ addAsset(`<a class="az-btn" target="_blank" rel="noopener" href="${link}">Open Link</a>`); }
+  }
+
+  function toBlobUrl(b64, mime){
+    try{
+      const bin = atob(b64); const arr = new Uint8Array(bin.length);
+      for(let i=0;i<bin.length;i++) arr[i] = bin.charCodeAt(i);
+      return URL.createObjectURL(new Blob([arr], {type:mime}));
+    }catch(e){ return null; }
+  }
+
+  function openWebhookModal(){
+    if(qs('.az-overlay')) return;
+    const wrap = document.createElement('div');
+    wrap.className = 'az-overlay';
+    wrap.innerHTML = `
+      <div class="az-modal">
+        <h3>Atualize seu WebHook para modo de produção</h3>
+        <div class="az-field"><label>Webhook URL</label><input id="aztra-webhook" type="url"></div>
+        <div class="az-row">
+          <button class="az-btn az-primary" data-aztra-act="save-webhook">Salvar e abrir conversa</button>
+          <button class="az-btn" data-aztra-act="close-modal">Cancelar</button>
+        </div>
+      </div>`;
+    document.body.appendChild(wrap);
+    const input = qs('#aztra-webhook');
+    input.value = localStorage.getItem('aztra_webhook') || '';
+    input.focus();
+  }
+})();

--- a/aztra-g-fall-animal/assets/editor.js
+++ b/aztra-g-fall-animal/assets/editor.js
@@ -1,0 +1,34 @@
+(function($){
+  function mountAztraTab(){
+    if (window.__AZTRA_TAB_MOUNTED__) return; // global guard
+    const $tabs = $('.elementor-panel-navigation .elementor-component-tabs');
+    if(!$tabs.length) return;
+    if($tabs.find('.aztra-tab').length){ window.__AZTRA_TAB_MOUNTED__ = true; return; }
+
+    const $adv = $tabs.find('.elementor-component-tab').last();
+    const $aztra = $adv.clone();
+    $aztra.removeClass('elementor-active').addClass('aztra-tab').attr('data-tab','aztra')
+      .find('.elementor-panel-navigation-tab-title').text('Aztra');
+    $adv.after($aztra);
+
+    $aztra.on('click', function(){
+      $tabs.find('.elementor-component-tab').removeClass('elementor-active');
+      $aztra.addClass('elementor-active');
+      const $panel = $('.elementor-control-sections');
+      $panel.find('.elementor-control-section').hide();
+      $panel.find('.elementor-control-section.aztra-section').show();
+      $panel.scrollTop(0);
+    });
+
+    $tabs.find('.elementor-component-tab').not('.aztra-tab').on('click', function(){
+      const $panel = $('.elementor-control-sections'); $panel.find('.elementor-control-section').show();
+    });
+
+    window.__AZTRA_TAB_MOUNTED__ = true;
+  }
+  if (window.elementor) {
+    elementor.hooks.addAction('panel/open_editor/widget', function(){
+      setTimeout(()=>mountAztraTab(), 80);
+    });
+  }
+})(jQuery);

--- a/aztra-g-fall-animal/assets/elementor.css
+++ b/aztra-g-fall-animal/assets/elementor.css
@@ -1,0 +1,32 @@
+/* Elementor skin for Aztra */
+.aztra-el-wrap { position: relative; width: 100%; margin-inline: auto; }
+.aztra-el-wrap .aztra-bg,
+.aztra-el-wrap::before { content:""; position:absolute; inset:0; pointer-events:none; z-index:0; }
+.aztra-el-card { position:relative; z-index:2; }
+
+/* animated gradient */
+.aztra-el-wrap[data-anim="gradient"] .aztra-bg {
+  background: radial-gradient(circle at 20% 20%, var(--g1, #7c3aed), transparent 40%),
+              radial-gradient(circle at 80% 70%, var(--g2, #06b6d4), transparent 45%),
+              linear-gradient(120deg, rgba(255,255,255,0.04), rgba(0,0,0,0.04));
+  animation: aztraFloat var(--gs, 18s) ease-in-out infinite alternate;
+  filter: saturate(1.1);
+}
+@keyframes aztraFloat {
+  0% { transform: translate3d(-2%, -2%, 0) scale(1); }
+  100% { transform: translate3d(2%, 2%, 0) scale(1.03); }
+}
+
+/* film noise */
+.aztra-el-wrap[data-anim="noise"] .aztra-bg {
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="160" height="160"><filter id="n"><feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="2"/></filter><rect width="100%" height="100%" filter="url(%23n)" opacity="0.15"/></svg>');
+  background-size: 160px 160px;
+  animation: aztraNoise 1.2s steps(2,end) infinite;
+}
+@keyframes aztraNoise { to { transform: translateY(-1px); } }
+
+/* video bg */
+.aztra-el-wrap[data-anim="video"] .aztra-bg { background:#000; overflow:hidden; }
+
+/* overlay only when has class */
+.aztra-el-wrap.has-overlay::before { background: var(--aztra-overlay, rgba(0,0,0,0.35)); z-index: 1; }

--- a/aztra-g-fall-animal/assets/elementor.js
+++ b/aztra-g-fall-animal/assets/elementor.js
@@ -1,0 +1,48 @@
+(function(){
+  function init(){
+    document.querySelectorAll('.aztra-el-wrap').forEach(wrap=>{
+      const anim = wrap.dataset.anim || 'none';
+      if(anim === 'gradient'){
+        const g1 = wrap.dataset.grad1 || '#7c3aed';
+        const g2 = wrap.dataset.grad2 || '#06b6d4';
+        const gs = wrap.dataset.gradSpeed || 18;
+        wrap.style.setProperty('--g1', g1);
+        wrap.style.setProperty('--g2', g2);
+        wrap.style.setProperty('--gs', gs + 's');
+      }
+      if(anim === 'particles'){ mountParticles(wrap); }
+      if(anim === 'video'){ mountVideo(wrap, wrap.dataset.video); }
+    });
+  }
+  function mountVideo(wrap, url){
+    if(!url) return;
+    const bg = wrap.querySelector('.aztra-bg'); if(!bg) return;
+    const v = document.createElement('video');
+    v.src = url; v.autoplay = true; v.loop = true; v.muted = true; v.playsInline = true;
+    Object.assign(v.style,{position:'absolute',inset:'0',width:'100%',height:'100%',objectFit:'cover'});
+    bg.innerHTML=''; bg.appendChild(v);
+  }
+  function mountParticles(wrap){
+    const bg = wrap.querySelector('.aztra-bg'); if(!bg) return;
+    const density = parseInt(wrap.dataset.particlesDensity || '120', 10);
+    const speed   = parseFloat(wrap.dataset.particlesSpeed || '0.6');
+    const c = document.createElement('canvas'); bg.innerHTML=''; bg.appendChild(c);
+    const ctx = c.getContext('2d'); let w,h,points=[];
+    function resize(){ w=bg.clientWidth; h=bg.clientHeight; c.width=w; c.height=h; makePoints(); }
+    function makePoints(){
+      points = Array.from({length: density}, ()=>({ x: Math.random()*w, y: Math.random()*h, vx:(Math.random()-0.5)*speed, vy:(Math.random()-0.5)*speed, r: Math.random()*1.8+0.2, a: Math.random()*0.4+0.2 }));
+    }
+    function tick(){
+      ctx.clearRect(0,0,w,h); ctx.fillStyle='#ffffff';
+      points.forEach(p=>{ p.x+=p.vx; p.y+=p.vy; if(p.x<0||p.x>w) p.vx*=-1; if(p.y<0||p.y>h) p.vy*=-1; ctx.globalAlpha=p.a; ctx.beginPath(); ctx.arc(p.x,p.y,p.r,0,Math.PI*2); ctx.fill(); });
+      requestAnimationFrame(tick);
+    }
+    new ResizeObserver(resize).observe(bg);
+    resize(); tick();
+  }
+  if(document.readyState !== 'loading') init();
+  else document.addEventListener('DOMContentLoaded', init);
+  if (window.elementorFrontend) {
+    window.elementorFrontend.hooks.addAction('frontend/element_ready/global', init);
+  }
+})();

--- a/aztra-g-fall-animal/aztra-g-fall-animal.php
+++ b/aztra-g-fall-animal/aztra-g-fall-animal.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Plugin Name: Aztra G Fall Animal
+ * Description: Hub multiuser with Elementor widgets, shortcodes and secure proxy to n8n workflow (Animal Flight). Includes Elementor "Aztra" top tab with background animations.
+ * Version: 1.2.0
+ * Author: Aztragroup
+ * Text Domain: aztra
+ */
+
+if (!defined('ABSPATH')) exit;
+
+// ---- Requirements ----
+if (version_compare(PHP_VERSION, '7.4', '<')) {
+  add_action('admin_notices', function(){
+    echo '<div class="notice notice-error"><p><b>Aztra G Fall Animal:</b> requires PHP 7.4 or higher.</p></div>';
+  });
+  return;
+}
+
+define('AZTRA_VER', '1.2.0');
+define('AZTRA_DIR', plugin_dir_path(__FILE__));
+define('AZTRA_URL', plugin_dir_url(__FILE__));
+
+// safe require helper
+if (!function_exists('aztra_require')) {
+  function aztra_require($rel){
+    $path = AZTRA_DIR . ltrim($rel, '/');
+    if (file_exists($path)) { require_once $path; return true; }
+    add_action('admin_notices', function() use ($rel){
+      echo '<div class="notice notice-warning"><p><b>Aztra:</b> missing file: <code>'.esc_html($rel).'</code></p></div>';
+    });
+    return false;
+  }
+}
+
+// includes
+aztra_require('includes/helpers.php');
+aztra_require('includes/activator.php');
+aztra_require('includes/class-aztra-cpt.php');
+aztra_require('includes/class-aztra-admin.php');
+aztra_require('includes/class-aztra-rest.php');
+aztra_require('includes/class-aztra-shortcodes.php');
+aztra_require('includes/class-aztra-elementor.php');
+
+class AztraG_Fall_Animal_Plugin {
+  public function __construct(){
+    if (class_exists('Aztra_Activator')) {
+      register_activation_hook(__FILE__, ['Aztra_Activator','activate']);
+    }
+    add_action('init', function(){
+      if (class_exists('Aztra_CPT')) Aztra_CPT::register();
+      if (class_exists('Aztra_Shortcodes')) Aztra_Shortcodes::register();
+    });
+    add_action('admin_menu', function(){
+      if (class_exists('Aztra_Admin')) Aztra_Admin::menu();
+    });
+    add_action('rest_api_init', function(){
+      if (class_exists('Aztra_REST')) Aztra_REST::routes();
+    });
+    add_action('plugins_loaded', function(){
+      if ( did_action('elementor/loaded') && class_exists('Aztra_Elementor') ) {
+        add_action('elementor/widgets/register', ['Aztra_Elementor','register_widgets']);
+      }
+    });
+    add_action('wp_enqueue_scripts', [$this,'register_assets']);
+    add_action('elementor/editor/after_enqueue_scripts', [$this,'editor_assets']);
+  }
+
+  public function register_assets(){
+    wp_register_style('aztra-app', AZTRA_URL.'assets/app.css', [], AZTRA_VER);
+    wp_register_style('aztra-el', AZTRA_URL.'assets/elementor.css', [], AZTRA_VER);
+    wp_register_script('aztra-app', AZTRA_URL.'assets/app.js', ['jquery'], AZTRA_VER, true);
+    wp_register_script('aztra-el', AZTRA_URL.'assets/elementor.js', [], AZTRA_VER, true);
+    wp_localize_script('aztra-app','AZTRA_CFG',[
+      'rest'=> esc_url_raw( rest_url('aztra/v1') ),
+      'nonce'=> wp_create_nonce('wp_rest'),
+      'tz'=> 'America/Sao_Paulo',
+      'chat_url'=> esc_url_raw( get_permalink( get_page_by_title('Aztra — Chat') ) ),
+    ]);
+  }
+
+  public function editor_assets(){
+    wp_enqueue_script('aztra-editor', AZTRA_URL.'assets/editor.js', ['jquery','elementor-editor'], AZTRA_VER, true);
+  }
+}
+new AztraG_Fall_Animal_Plugin();

--- a/aztra-g-fall-animal/includes/activator.php
+++ b/aztra-g-fall-animal/includes/activator.php
@@ -1,0 +1,35 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class Aztra_Activator {
+  public static function activate(){
+    // default settings
+    if (!get_option('aztra_g_settings')) {
+      update_option('aztra_g_settings',[
+        'webhook'=>'https://n8n.srv957470.hstgr.cloud/webhook/444b9fdb-cdf0-43b5-81d8-7126b2a8f5ec',
+        'access_code'=>'444b9fdb',
+        'animals'=>"camel\ncapybara\nred fox\njaguar\npanda\nkoala\nkangaroo\nwolf\nbear",
+        'scenarios'=>"Egypt • Giza Pyramids • low desert dunes\nBrazil • Rio • Copacabana + Sugarloaf\nIceland • black-sand beach\nUSA • Grand Canyon",
+        'time_of_day'=>"sunrise\ngolden hour\nsunset\nblue hour\nnight sky",
+        'weather'=>"clear\nclear with soft haze\nscattered clouds\nfoggy\nlight snow",
+        'flight_style'=>"slow hover\nslow glide with gentle banking\nsmooth lateral drift",
+        'camera_movement'=>"smooth forward drift with slight parallax\ngentle push-in\nlow skim over ground",
+        'style'=>"cinematic photorealism\nhyperreal nature doc\ndreamlike realism",
+      ], false);
+    }
+    // create pages with shortcodes
+    $pages = [
+      'Aztra — Home'   => '[aztra_home]',
+      'Aztra — Chat'   => '[aztra_chat]',
+      'Aztra — Login'  => '[aztra_login]',
+      'Aztra — Signup' => '[aztra_signup]',
+      'Aztra — App'    => '[aztra_builder]',
+      'Aztra — Gallery'=> '[aztra_gallery]',
+    ];
+    foreach($pages as $title=>$sc){
+      if(!get_page_by_title($title)){
+        wp_insert_post(['post_title'=>$title,'post_status'=>'publish','post_type'=>'page','post_content'=>$sc]);
+      }
+    }
+  }
+}

--- a/aztra-g-fall-animal/includes/class-aztra-admin.php
+++ b/aztra-g-fall-animal/includes/class-aztra-admin.php
@@ -1,0 +1,73 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class Aztra_Admin {
+  public static function menu(){
+    add_menu_page('Aztra G','Aztra G','edit_posts','aztra-hub',[__CLASS__,'hub'],'dashicons-art',56);
+    add_submenu_page('aztra-hub','Dashboard','Dashboard','edit_posts','aztra-hub',[__CLASS__,'hub']);
+    add_submenu_page('aztra-hub','Settings','Settings','manage_options','aztra-settings',[__CLASS__,'settings']);
+    add_submenu_page('aztra-hub','Requests','Requests','edit_posts','edit.php?post_type=aztra_request');
+  }
+
+  public static function hub(){
+    $count = wp_count_posts('aztra_request');
+    ?>
+    <div class="wrap">
+      <h1>Aztra G — Dashboard</h1>
+      <p>Use the generated pages or shortcodes to build your front end.</p>
+      <ul>
+        <li><b>Total Requests:</b> <?php echo intval($count->publish ?? 0); ?></li>
+        <li><a href="<?php echo admin_url('edit.php?post_type=aztra_request'); ?>">View all requests</a></li>
+        <li><a href="<?php echo admin_url('admin.php?page=aztra-settings'); ?>">Plugin settings</a></li>
+      </ul>
+      <p>Shortcodes:</p>
+      <ul>
+        <li><code>[aztra_home]</code> – landing with preview and webhook modal</li>
+        <li><code>[aztra_chat]</code> – two-column chat interface</li>
+        <li><code>[aztra_builder]</code> – model builder form</li>
+        <li><code>[aztra_gallery]</code> – saved responses for the user</li>
+        <li><code>[aztra_login]</code> / <code>[aztra_signup]</code> – basic auth pages</li>
+      </ul>
+    </div>
+    <?php
+  }
+
+  public static function settings(){
+    if(isset($_POST['aztra_save']) && current_user_can('manage_options')){
+      check_admin_referer('aztra_save');
+      $fields = ['webhook','access_code','animals','scenarios','time_of_day','weather','flight_style','camera_movement','style'];
+      $opts = [];
+      foreach($fields as $f){ $opts[$f] = wp_unslash($_POST[$f] ?? ''); }
+      update_option('aztra_g_settings', $opts, false);
+      echo '<div class="updated"><p>Saved.</p></div>';
+    }
+    $o = get_option('aztra_g_settings',[]);
+    ?>
+    <div class="wrap"><h1>Aztra G — Settings</h1>
+      <form method="post"><?php wp_nonce_field('aztra_save'); ?>
+        <table class="form-table">
+          <tr><th>Webhook URL (n8n)</th>
+            <td><input name="webhook" type="url" style="width:520px" value="<?php echo esc_attr($o['webhook'] ?? ''); ?>"></td></tr>
+          <tr><th>Access code (signup)</th>
+            <td><input name="access_code" type="text" value="<?php echo esc_attr($o['access_code'] ?? ''); ?>"></td></tr>
+          <tr><th>Animals (1 per line)</th>
+            <td><textarea name="animals" rows="6" style="width:520px"><?php echo esc_textarea($o['animals'] ?? ''); ?></textarea></td></tr>
+          <tr><th>Scenarios</th>
+            <td><textarea name="scenarios" rows="6" style="width:520px"><?php echo esc_textarea($o['scenarios'] ?? ''); ?></textarea></td></tr>
+          <tr><th>Time of day</th>
+            <td><textarea name="time_of_day" rows="4" style="width:520px"><?php echo esc_textarea($o['time_of_day'] ?? ''); ?></textarea></td></tr>
+          <tr><th>Weather</th>
+            <td><textarea name="weather" rows="4" style="width:520px"><?php echo esc_textarea($o['weather'] ?? ''); ?></textarea></td></tr>
+          <tr><th>Flight style</th>
+            <td><textarea name="flight_style" rows="4" style="width:520px"><?php echo esc_textarea($o['flight_style'] ?? ''); ?></textarea></td></tr>
+          <tr><th>Camera movement</th>
+            <td><textarea name="camera_movement" rows="4" style="width:520px"><?php echo esc_textarea($o['camera_movement'] ?? ''); ?></textarea></td></tr>
+          <tr><th>Style</th>
+            <td><textarea name="style" rows="4" style="width:520px"><?php echo esc_textarea($o['style'] ?? ''); ?></textarea></td></tr>
+        </table>
+        <p><button class="button-primary" name="aztra_save" value="1">Save</button></p>
+      </form>
+    </div>
+    <?php
+  }
+}

--- a/aztra-g-fall-animal/includes/class-aztra-cpt.php
+++ b/aztra-g-fall-animal/includes/class-aztra-cpt.php
@@ -1,0 +1,51 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class Aztra_CPT {
+  public static function register(){
+    register_post_type('aztra_request',[
+      'label'=>'Aztra Requests','public'=>false,'show_ui'=>true,'show_in_menu'=>'aztra-hub',
+      'menu_icon'=>'dashicons-video-alt3',
+      'supports'=>['title','author','thumbnail'],
+    ]);
+  }
+
+  public static function store_request($fields, $resp){
+    $title = ($resp['outputFileName'] ?? $resp['conceptTitle'] ?? 'Aztra Request').' — '.current_time('mysql');
+    $post_id = wp_insert_post([
+      'post_type'=>'aztra_request','post_status'=>'publish',
+      'post_title'=>$title,'post_author'=> get_current_user_id(),
+    ]);
+
+    update_post_meta($post_id,'aztra_fields',$fields);
+    update_post_meta($post_id,'aztra_response',$resp);
+
+    // Attach base64 images/videos if present
+    if(isset($resp['binary']) && is_array($resp['binary'])){
+      foreach($resp['binary'] as $key=>$bin){
+        if(!empty($bin['data'])){
+          self::attach_b64($post_id, $bin['data'], $bin['fileName'] ?? ($key.'.bin'), $bin['mimeType'] ?? 'application/octet-stream');
+        }
+      }
+    }
+    if(isset($resp['data'][0]['b64_json'])){
+      self::attach_b64($post_id, $resp['data'][0]['b64_json'], 'image.png', 'image/png');
+    }
+    if(!empty($resp['webViewLink']) || !empty($resp['webContentLink'])){
+      update_post_meta($post_id,'aztra_links', array_filter([$resp['webViewLink'] ?? null, $resp['webContentLink'] ?? null]));
+    }
+    return $post_id;
+  }
+
+  private static function attach_b64($post_id, $b64, $name, $mime){
+    $bits = wp_upload_bits($name, null, base64_decode($b64));
+    if(!empty($bits['error'])) return;
+    $filetype = wp_check_filetype($bits['file']);
+    $attach_id = wp_insert_attachment([
+      'post_mime_type'=>$filetype['type'] ?: $mime,
+      'post_title'=>$name,'post_status'=>'inherit','post_parent'=>$post_id
+    ], $bits['file'], $post_id);
+    require_once ABSPATH.'wp-admin/includes/image.php';
+    wp_update_attachment_metadata($attach_id, wp_generate_attachment_metadata($attach_id, $bits['file']));
+  }
+}

--- a/aztra-g-fall-animal/includes/class-aztra-elementor.php
+++ b/aztra-g-fall-animal/includes/class-aztra-elementor.php
@@ -1,0 +1,18 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class Aztra_Elementor {
+  public static function register_widgets($widgets_manager){
+    $base = AZTRA_DIR.'includes/widgets/';
+    require_once $base.'trait-aztra-controls.php';
+    require_once $base.'class-aztra-el-login.php';
+    require_once $base.'class-aztra-el-signup.php';
+    require_once $base.'class-aztra-el-builder.php';
+    require_once $base.'class-aztra-el-gallery.php';
+
+    $widgets_manager->register( new \Aztra_El_Login() );
+    $widgets_manager->register( new \Aztra_El_Signup() );
+    $widgets_manager->register( new \Aztra_El_Builder() );
+    $widgets_manager->register( new \Aztra_El_Gallery() );
+  }
+}

--- a/aztra-g-fall-animal/includes/class-aztra-rest.php
+++ b/aztra-g-fall-animal/includes/class-aztra-rest.php
@@ -1,0 +1,99 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class Aztra_REST {
+  public static function routes(){
+    register_rest_route('aztra/v1','/generate',[
+      'methods'=>'POST',
+      'permission_callback'=>function(){ return is_user_logged_in() && wp_verify_nonce($_REQUEST['_wpnonce'] ?? '', 'wp_rest'); },
+      'callback'=>[__CLASS__,'generate'],
+    ]);
+    register_rest_route('aztra/v1','/signup',[
+      'methods'=>'POST',
+      'permission_callback'=>'__return_true',
+      'callback'=>[__CLASS__,'signup'],
+    ]);
+    register_rest_route('aztra/v1','/lists',[
+      'methods'=>'GET',
+      'permission_callback'=>'__return_true',
+      'callback'=>[__CLASS__,'lists'],
+    ]);
+  }
+
+  public static function settings(){
+    $defaults = [
+      'webhook'=>'https://n8n.srv957470.hstgr.cloud/webhook/444b9fdb-cdf0-43b5-81d8-7126b2a8f5ec',
+      'access_code'=>'444b9fdb',
+      'animals'=>"camel\ncapybara\nred fox\njaguar\npanda\nkoala\nkangaroo\nwolf\nbear",
+      'scenarios'=>"Egypt • Giza Pyramids • low desert dunes\nBrazil • Rio • Copacabana + Sugarloaf\nIceland • black-sand beach\nUSA • Grand Canyon",
+      'time_of_day'=>"sunrise\ngolden hour\nsunset\nblue hour\nnight sky",
+      'weather'=>"clear\nclear with soft haze\nscattered clouds\nfoggy\nlight snow",
+      'flight_style'=>"slow hover\nslow glide with gentle banking\nsmooth lateral drift",
+      'camera_movement'=>"smooth forward drift with slight parallax\ngentle push-in\nlow skim over ground",
+      'style'=>"cinematic photorealism\nhyperreal nature doc\ndreamlike realism",
+    ];
+    return wp_parse_args(get_option('aztra_g_settings',[]), $defaults);
+  }
+
+  public static function lists($req){
+    $o = self::settings();
+    require_once AZTRA_DIR.'includes/helpers.php';
+    return [
+      'animals'=> aztra_arr_lines($o['animals']),
+      'scenarios'=> aztra_arr_lines($o['scenarios']),
+      'time_of_day'=> aztra_arr_lines($o['time_of_day']),
+      'weather'=> aztra_arr_lines($o['weather']),
+      'flight_style'=> aztra_arr_lines($o['flight_style']),
+      'camera_movement'=> aztra_arr_lines($o['camera_movement']),
+      'style'=> aztra_arr_lines($o['style']),
+    ];
+  }
+
+  public static function signup($req){
+    $code = sanitize_text_field($req['code'] ?? '');
+    $o = self::settings();
+    if ($code !== $o['access_code']) return new WP_Error('forbidden','Invalid access code',['status'=>403]);
+    $u = sanitize_user($req['username'] ?? '');
+    $p = $req['password'] ?? '';
+    if(!$u || !$p) return new WP_Error('bad_request','Missing fields',['status'=>400]);
+    if(username_exists($u)) return new WP_Error('conflict','User exists',['status'=>409]);
+    $id = wp_create_user($u,$p,$u.'@example.com');
+    if(is_wp_error($id)) return $id;
+    return ['ok'=>true,'user_id'=>$id];
+  }
+
+  public static function generate($req){
+    $o = self::settings();
+    $webhook = $o['webhook'];
+    $user = wp_get_current_user()->user_login;
+    $tz = new DateTimeZone('America/Sao_Paulo');
+    $ts = (new DateTime('now',$tz))->format('d/m/Y H:i:s');
+
+    $payload = [
+      'animal'=> sanitize_text_field($req['animal'] ?? ''),
+      'scenario'=> sanitize_text_field($req['scenario'] ?? ''),
+      'time_of_day'=> sanitize_text_field($req['time_of_day'] ?? ''),
+      'weather'=> sanitize_text_field($req['weather'] ?? ''),
+      'flight_style'=> sanitize_text_field($req['flight_style'] ?? ''),
+      'camera_movement'=> sanitize_text_field($req['camera_movement'] ?? ''),
+      'style'=> sanitize_text_field($req['style'] ?? ''),
+      'user'=> $user,
+      'timestamp_sp'=> $ts,
+    ];
+
+    $r = wp_remote_post($webhook, [
+      'headers'=>['Content-Type'=>'application/json'],
+      'timeout'=>60,
+      'body'=> wp_json_encode($payload),
+    ]);
+    if(is_wp_error($r)) return $r;
+    $body = wp_remote_retrieve_body($r);
+    $json = json_decode($body, true);
+    if(!$json) $json = ['raw'=>$body];
+
+    if (class_exists('Aztra_CPT')) {
+      Aztra_CPT::store_request($payload, $json);
+    }
+    return ['ok'=>true,'data'=>$json];
+  }
+}

--- a/aztra-g-fall-animal/includes/class-aztra-shortcodes.php
+++ b/aztra-g-fall-animal/includes/class-aztra-shortcodes.php
@@ -1,0 +1,185 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+class Aztra_Shortcodes {
+  public static function register(){
+    add_shortcode('aztra_login', [__CLASS__, 'login']);
+    add_shortcode('aztra_signup', [__CLASS__, 'signup']);
+    add_shortcode('aztra_builder', [__CLASS__, 'builder']);
+    add_shortcode('aztra_gallery', [__CLASS__, 'gallery']);
+    add_shortcode('aztra_home', [__CLASS__, 'home']);
+    add_shortcode('aztra_chat', [__CLASS__, 'chat']);
+  }
+
+  private static function render_header(){
+    ?>
+    <header class="az-header">
+      <div class="az-brand">Aztra&nbsp;G</div>
+      <nav class="az-nav">
+        <button class="az-btn" data-aztra-act="toggle-theme">Tema</button>
+      </nav>
+    </header>
+    <?php
+  }
+
+  private static function render_footer(){
+    ?>
+    <footer class="az-footer">
+      <a href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Tutoriais') ) ); ?>">Tutoriais</a>
+    </footer>
+    <?php
+  }
+
+  public static function login($atts=[]){
+    wp_enqueue_style('aztra-app'); wp_enqueue_script('aztra-app');
+    ob_start(); ?>
+    <div class="az-card">
+      <h2>Login</h2>
+      <?php if(!is_user_logged_in()): ?>
+        <form method="post" action="<?php echo esc_url( wp_login_url() ); ?>">
+          <div class="az-field"><label>Username</label><input name="log" required></div>
+          <div class="az-field"><label>Password</label><input type="password" name="pwd" required></div>
+          <button class="az-btn">Login</button>
+        </form>
+        <p>Don't have an account? <a href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Signup') ) ); ?>">Create account</a></p>
+      <?php else: ?>
+        <p>You're logged in. <a href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — App') ) ); ?>">Open App</a></p>
+      <?php endif; ?>
+    </div>
+    <?php return ob_get_clean();
+  }
+
+  public static function signup($atts = []){
+    wp_enqueue_style('aztra-app'); wp_enqueue_script('aztra-app');
+    $a = shortcode_atts([
+      'title' => 'Create account',
+      'subtitle' => 'Use your access code to join.',
+      'label_username' => 'Username',
+      'label_password' => 'Password',
+      'label_access' => 'Access code',
+      'placeholder_access' => 'Enter your access code',
+      'button' => 'Create account',
+    ], $atts, 'aztra_signup');
+
+    ob_start(); ?>
+    <div class="az-card" data-aztra-login-url="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Login') ) ); ?>">
+      <h2><?php echo esc_html($a['title']); ?></h2>
+      <?php if(!empty($a['subtitle'])): ?><p class="az-sub"><?php echo esc_html($a['subtitle']); ?></p><?php endif; ?>
+      <div class="az-field"><label><?php echo esc_html($a['label_username']); ?></label><input id="az-su-user"></div>
+      <div class="az-field"><label><?php echo esc_html($a['label_password']); ?></label><input id="az-su-pass" type="password"></div>
+      <div class="az-field"><label><?php echo esc_html($a['label_access']); ?></label>
+        <input id="az-su-code" autocomplete="off" placeholder="<?php echo esc_attr($a['placeholder_access']); ?>"></div>
+      <button class="az-btn az-primary" data-aztra-act="signup" type="button"><?php echo esc_html($a['button']); ?></button>
+    </div>
+    <?php return ob_get_clean();
+  }
+
+  public static function builder($atts=[]){
+    if(!is_user_logged_in()){ return '<p>Please log in to use the app.</p>'; }
+    wp_enqueue_style('aztra-app'); wp_enqueue_style('aztra-el'); wp_enqueue_script('aztra-app'); wp_enqueue_script('aztra-el');
+    ob_start(); ?>
+    <div class="az-grid">
+      <div class="az-card">
+        <h3>Builder</h3>
+        <form id="aztra-form">
+          <div class="az-grid-2">
+            <div class="az-field"><label>Animal</label><select id="animal" name="animal"></select></div>
+            <div class="az-field"><label>Scenario</label><select id="scenario" name="scenario"></select></div>
+            <div class="az-field"><label>Time of day</label><select id="time_of_day" name="time_of_day"></select></div>
+            <div class="az-field"><label>Weather</label><select id="weather" name="weather"></select></div>
+            <div class="az-field"><label>Flight style</label><select id="flight_style" name="flight_style"></select></div>
+            <div class="az-field"><label>Camera movement</label><select id="camera_movement" name="camera_movement"></select></div>
+            <div class="az-field az-col-2"><label>Style</label><select id="style" name="style"></select></div>
+          </div>
+          <button class="az-btn az-primary" type="button" data-aztra-act="generate">Send to Workflow</button>
+        </form>
+      </div>
+
+      <div class="az-card">
+        <h3>Live Response</h3>
+        <pre id="aztra-response">{}</pre>
+        <h4>Assets</h4>
+        <div id="aztra-assets" class="az-assets"></div>
+      </div>
+    </div>
+    <?php return ob_get_clean();
+  }
+
+  public static function gallery($atts=[]){
+    if(!is_user_logged_in()){ return '<p>Please log in to view your gallery.</p>'; }
+    wp_enqueue_style('aztra-app');
+    $q = new WP_Query([
+      'post_type'=>'aztra_request',
+      'posts_per_page'=>20,
+      'author'=> get_current_user_id(),
+      'orderby'=>'date','order'=>'DESC'
+    ]);
+    ob_start(); ?>
+    <div class="az-grid">
+      <?php if($q->have_posts()): while($q->have_posts()): $q->the_post();
+        $resp = get_post_meta(get_the_ID(),'aztra_response',true);
+        $links = get_post_meta(get_the_ID(),'aztra_links',true);
+        $atts = get_attached_media('', get_the_ID());
+      ?>
+        <div class="az-card">
+          <h4><?php the_title(); ?></h4>
+          <div class="az-assets">
+            <?php foreach($atts as $att): $url = wp_get_attachment_url($att->ID); $type = get_post_mime_type($att->ID); ?>
+              <?php if(strpos($type,'image/')===0): ?>
+                <img src="<?php echo esc_url($url); ?>" class="az-thumb" />
+              <?php elseif(strpos($type,'video/')===0): ?>
+                <video controls class="az-thumb"><source src="<?php echo esc_url($url); ?>"></video>
+              <?php else: ?>
+                <a class="az-btn" href="<?php echo esc_url($url); ?>" target="_blank">Download</a>
+              <?php endif; ?>
+            <?php endforeach; ?>
+            <?php if(!empty($links)): foreach((array)$links as $link): ?>
+              <a class="az-btn" href="<?php echo esc_url($link); ?>" target="_blank" rel="noopener">Open Link</a>
+            <?php endforeach; endif; ?>
+          </div>
+          <?php if(!empty($resp)): ?><details><summary>JSON</summary><pre><?php echo esc_html(json_encode($resp, JSON_PRETTY_PRINT|JSON_UNESCAPED_SLASHES)); ?></pre></details><?php endif; ?>
+        </div>
+      <?php endwhile; else: ?>
+        <p>No items yet.</p>
+      <?php endif; wp_reset_postdata(); ?>
+    </div>
+    <?php return ob_get_clean();
+  }
+
+  public static function home($atts=[]){
+    wp_enqueue_style('aztra-app'); wp_enqueue_script('aztra-app');
+    ob_start();
+    self::render_header(); ?>
+    <div class="az-home">
+      <p>utilize o webhook teste para testar</p>
+      <pre id="aztra-preview">{}</pre>
+      <button class="az-btn az-primary" data-aztra-act="open-save-model">Salvar Modelo e iniciar conversa</button>
+    </div>
+    <?php self::render_footer();
+    return ob_get_clean();
+  }
+
+  public static function chat($atts=[]){
+    if(!is_user_logged_in()){ return '<p>Please log in to use the chat.</p>'; }
+    wp_enqueue_style('aztra-app'); wp_enqueue_script('aztra-app');
+    ob_start();
+    self::render_header(); ?>
+    <div class="az-chat-layout">
+      <aside class="az-sidebar">
+        <button class="az-btn" data-aztra-act="new-chat">Novo chat</button>
+        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Gallery') ) ); ?>">Galeria</a>
+        <button class="az-btn" data-aztra-act="new-project">Novo Projeto</button>
+        <div class="az-label">Projeto Aztra G</div>
+        <button class="az-btn" data-aztra-act="user-settings">Configurações de usuário</button>
+      </aside>
+      <section class="az-chat">
+        <div id="aztra-chat-log" class="az-chat-log"></div>
+        <div class="az-field"><input id="aztra-chat-file" type="file" multiple></div>
+        <div class="az-field"><textarea id="aztra-chat-message" rows="3" placeholder="Digite sua mensagem..."></textarea></div>
+        <button class="az-btn az-primary" data-aztra-act="send-chat">Enviar</button>
+      </section>
+    </div>
+    <?php self::render_footer();
+    return ob_get_clean();
+  }
+}

--- a/aztra-g-fall-animal/includes/helpers.php
+++ b/aztra-g-fall-animal/includes/helpers.php
@@ -1,0 +1,17 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+if (!function_exists('aztra_log')) {
+  function aztra_log($msg){
+    if (defined('WP_DEBUG') && WP_DEBUG) {
+      error_log( is_scalar($msg) ? $msg : print_r($msg, true) );
+    }
+  }
+}
+
+if (!function_exists('aztra_arr_lines')) {
+  function aztra_arr_lines($s){
+    $arr = array_map('trim', explode("\n", (string)$s));
+    return array_values(array_filter($arr));
+  }
+}

--- a/aztra-g-fall-animal/includes/widgets/class-aztra-el-builder.php
+++ b/aztra-g-fall-animal/includes/widgets/class-aztra-el-builder.php
@@ -1,0 +1,33 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+require_once __DIR__.'/trait-aztra-controls.php';
+
+class Aztra_El_Builder extends Widget_Base {
+  use Aztra_Controls_Trait;
+
+  public function get_name() { return 'aztra_builder'; }
+  public function get_title() { return 'Aztra Builder'; }
+  public function get_icon() { return 'eicon-edit'; }
+  public function get_categories() { return ['general']; }
+  public function get_style_depends() { return ['aztra-app','aztra-el']; }
+  public function get_script_depends() { return ['aztra-app','aztra-el']; }
+
+  protected function register_controls() {
+    $this->start_controls_section('aztra_builder_content', [
+      'label'=>'Builder — Content','tab'=>Controls_Manager::TAB_CONTENT,
+    ]);
+    $this->add_control('title', ['label'=>'Title','type'=>Controls_Manager::TEXT,'default'=>'Builder']);
+    $this->end_controls_section();
+    $this->aztra_register_controls();
+  }
+
+  protected function render() {
+    $s = $this->get_settings_for_display();
+    echo '<div '.$this->aztra_wrapper_attrs($s).'><div class="aztra-bg"></div><div class="aztra-el-card">';
+    echo do_shortcode('[aztra_builder]');
+    echo '</div></div>';
+  }
+}

--- a/aztra-g-fall-animal/includes/widgets/class-aztra-el-gallery.php
+++ b/aztra-g-fall-animal/includes/widgets/class-aztra-el-gallery.php
@@ -1,0 +1,33 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+require_once __DIR__.'/trait-aztra-controls.php';
+
+class Aztra_El_Gallery extends Widget_Base {
+  use Aztra_Controls_Trait;
+
+  public function get_name() { return 'aztra_gallery'; }
+  public function get_title() { return 'Aztra Gallery'; }
+  public function get_icon() { return 'eicon-gallery-grid'; }
+  public function get_categories() { return ['general']; }
+  public function get_style_depends() { return ['aztra-app','aztra-el']; }
+  public function get_script_depends() { return ['aztra-app','aztra-el']; }
+
+  protected function register_controls() {
+    $this->start_controls_section('aztra_gallery_content', [
+      'label'=>'Gallery — Content','tab'=>Controls_Manager::TAB_CONTENT,
+    ]);
+    $this->add_control('title', ['label'=>'Title','type'=>Controls_Manager::TEXT,'default'=>'Gallery']);
+    $this->end_controls_section();
+    $this->aztra_register_controls();
+  }
+
+  protected function render() {
+    $s = $this->get_settings_for_display();
+    echo '<div '.$this->aztra_wrapper_attrs($s).'><div class="aztra-bg"></div><div class="aztra-el-card">';
+    echo do_shortcode('[aztra_gallery]');
+    echo '</div></div>';
+  }
+}

--- a/aztra-g-fall-animal/includes/widgets/class-aztra-el-login.php
+++ b/aztra-g-fall-animal/includes/widgets/class-aztra-el-login.php
@@ -1,0 +1,34 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+require_once __DIR__.'/trait-aztra-controls.php';
+
+class Aztra_El_Login extends Widget_Base {
+  use Aztra_Controls_Trait;
+
+  public function get_name() { return 'aztra_login'; }
+  public function get_title() { return 'Aztra Login'; }
+  public function get_icon() { return 'eicon-lock-user'; }
+  public function get_categories() { return ['general']; }
+  public function get_style_depends() { return ['aztra-app','aztra-el']; }
+  public function get_script_depends() { return ['aztra-app','aztra-el']; }
+
+  protected function register_controls() {
+    $this->start_controls_section('aztra_login_content', [
+      'label'=>'Login Content','tab'=>Controls_Manager::TAB_CONTENT,
+    ]);
+    $this->add_control('title', ['label'=>'Title','type'=>Controls_Manager::TEXT,'default'=>'Login']);
+    $this->add_control('button_text', ['label'=>'Button','type'=>Controls_Manager::TEXT,'default'=>'Login']);
+    $this->end_controls_section();
+    $this->aztra_register_controls();
+  }
+
+  protected function render() {
+    $s = $this->get_settings_for_display();
+    echo '<div '.$this->aztra_wrapper_attrs($s).'><div class="aztra-bg"></div><div class="aztra-el-card">';
+    echo do_shortcode('[aztra_login]');
+    echo '</div></div>';
+  }
+}

--- a/aztra-g-fall-animal/includes/widgets/class-aztra-el-signup.php
+++ b/aztra-g-fall-animal/includes/widgets/class-aztra-el-signup.php
@@ -1,0 +1,44 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+require_once __DIR__.'/trait-aztra-controls.php';
+
+class Aztra_El_Signup extends Widget_Base {
+  use Aztra_Controls_Trait;
+
+  public function get_name() { return 'aztra_signup'; }
+  public function get_title() { return 'Aztra Signup'; }
+  public function get_icon() { return 'eicon-user-circle-o'; }
+  public function get_categories() { return ['general']; }
+  public function get_style_depends() { return ['aztra-app','aztra-el']; }
+  public function get_script_depends() { return ['aztra-app','aztra-el']; }
+
+  protected function register_controls() {
+    $this->start_controls_section('aztra_signup_content', [
+      'label'=>'Signup — Content', 'tab'=>Controls_Manager::TAB_CONTENT,
+    ]);
+    $this->add_control('title', ['label'=>'Title','type'=>Controls_Manager::TEXT,'default'=>'Create account','label_block'=>true]);
+    $this->add_control('subtitle', ['label'=>'Subtitle','type'=>Controls_Manager::TEXTAREA,'default'=>'Use your access code to join.','rows'=>2]);
+    $this->add_control('label_username', ['label'=>'Label: Username','type'=>Controls_Manager::TEXT,'default'=>'Username']);
+    $this->add_control('label_password', ['label'=>'Label: Password','type'=>Controls_Manager::TEXT,'default'=>'Password']);
+    $this->add_control('label_access', ['label'=>'Label: Access code','type'=>Controls_Manager::TEXT,'default'=>'Access code']);
+    $this->add_control('placeholder_access', ['label'=>'Placeholder: Access code','type'=>Controls_Manager::TEXT,'default'=>'Enter your access code']);
+    $this->add_control('button_text', ['label'=>'Button text','type'=>Controls_Manager::TEXT,'default'=>'Create account']);
+    $this->end_controls_section();
+    $this->aztra_register_controls();
+  }
+
+  protected function render() {
+    $s = $this->get_settings_for_display();
+    $sc = sprintf(
+      '[aztra_signup title="%s" subtitle="%s" label_username="%s" label_password="%s" label_access="%s" placeholder_access="%s" button="%s"]',
+      esc_attr($s['title']), esc_attr($s['subtitle']), esc_attr($s['label_username']),
+      esc_attr($s['label_password']), esc_attr($s['label_access']), esc_attr($s['placeholder_access']), esc_attr($s['button_text'])
+    );
+    echo '<div '.$this->aztra_wrapper_attrs($s).'><div class="aztra-bg"></div><div class="aztra-el-card">';
+    echo do_shortcode($sc);
+    echo '</div></div>';
+  }
+}

--- a/aztra-g-fall-animal/includes/widgets/trait-aztra-controls.php
+++ b/aztra-g-fall-animal/includes/widgets/trait-aztra-controls.php
@@ -1,0 +1,162 @@
+<?php
+if (!defined('ABSPATH')) exit;
+
+use Elementor\Controls_Manager;
+use Elementor\Group_Control_Border;
+use Elementor\Group_Control_Box_Shadow;
+use Elementor\Group_Control_Typography;
+
+trait Aztra_Controls_Trait {
+  protected function aztra_register_controls() {
+    // STYLE (typography & colors)
+    $this->start_controls_section('aztra_style_section', [
+      'label'   => 'Aztra Style',
+      'tab'     => Controls_Manager::TAB_STYLE,
+      'classes' => 'aztra-section',
+    ]);
+    $this->add_control('aztra_text_color', [
+      'label'=>'Text Color','type'=>Controls_Manager::COLOR,
+      'selectors'=>['{{WRAPPER}} .aztra-el-card'=>'color: {{VALUE}};','{{WRAPPER}} .az-card'=>'--az-card-color: {{VALUE}};'],
+    ]);
+    $this->add_group_control(Group_Control_Typography::get_type(), [
+      'name'=>'aztra_heading_typo', 'label'=>'Heading Typography',
+      'selector'=>'{{WRAPPER}} .aztra-el-card h1, {{WRAPPER}} .aztra-el-card h2, {{WRAPPER}} .aztra-el-card h3, {{WRAPPER}} .aztra-el-card h4',
+    ]);
+    $this->add_group_control(Group_Control_Typography::get_type(), [
+      'name'=>'aztra_body_typo', 'label'=>'Body Typography',
+      'selector'=>'{{WRAPPER}} .aztra-el-card, {{WRAPPER}} .aztra-el-card input, {{WRAPPER}} .aztra-el-card select, {{WRAPPER}} .aztra-el-card button',
+    ]);
+    $this->add_control('aztra_card_background', [
+      'label'=>'Card Background',
+      'type'=>Controls_Manager::COLOR,
+      'selectors'=>['{{WRAPPER}} .aztra-el-card'=>'background: {{VALUE}};','{{WRAPPER}} .az-card'=>'--az-card-bg: {{VALUE}};'],
+      'description'=>'Use rgba with alpha 0 to make it transparent.'
+    ]);
+    $this->add_control('aztra_btn_bg', [
+      'label'=>'Primary Button BG (gradient or color)',
+      'type'=>Controls_Manager::TEXT,
+      'default'=>'linear-gradient(135deg,#7c3aed,#06b6d4)',
+      'selectors'=>['{{WRAPPER}} .aztra-el-card .az-btn.az-primary'=>'background: {{VALUE}};','{{WRAPPER}} .az-card'=>'--az-btn-bg: {{VALUE}};'],
+    ]);
+    $this->end_controls_section();
+
+    // LAYOUT
+    $this->start_controls_section('aztra_layout', [
+      'label'   => 'Aztra Layout',
+      'tab'     => Controls_Manager::TAB_ADVANCED,
+      'classes' => 'aztra-section',
+    ]);
+    $this->add_responsive_control('aztra_max_width', [
+      'label' => 'Max Width (px)',
+      'type'  => Controls_Manager::SLIDER,
+      'range' => [ 'px' => [ 'min'=>280,'max'=>1600 ] ],
+      'selectors' => [ '{{WRAPPER}} .aztra-el-wrap' => 'max-width: {{SIZE}}{{UNIT}};' ],
+    ]);
+    $this->add_responsive_control('aztra_padding', [
+      'label' => 'Card Padding',
+      'type'  => Controls_Manager::DIMENSIONS,
+      'size_units' => ['px','em','%'],
+      'selectors' => [ '{{WRAPPER}} .aztra-el-card' => 'padding: {{TOP}}{{UNIT}} {{RIGHT}}{{UNIT}} {{BOTTOM}}{{UNIT}} {{LEFT}}{{UNIT}};' ],
+    ]);
+    $this->add_group_control(Group_Control_Border::get_type(), [
+      'name' => 'aztra_border',
+      'selector' => '{{WRAPPER}} .aztra-el-card',
+    ]);
+    $this->add_group_control(Group_Control_Box_Shadow::get_type(), [
+      'name' => 'aztra_shadow',
+      'selector' => '{{WRAPPER}} .aztra-el-card',
+    ]);
+    $this->add_control('aztra_radius', [
+      'label'=>'Border Radius',
+      'type'=>Controls_Manager::SLIDER,
+      'range'=>['px'=>['min'=>0,'max'=>48]],
+      'selectors'=>['{{WRAPPER}} .aztra-el-card'=>'border-radius: {{SIZE}}{{UNIT}};'],
+    ]);
+    $this->end_controls_section();
+
+    // CUSTOMIZATION (BG animations + overlay)
+    $this->start_controls_section('aztra_custom', [
+      'label'   => 'Aztra Customization',
+      'tab'     => Controls_Manager::TAB_ADVANCED,
+      'classes' => 'aztra-section',
+    ]);
+    $this->add_control('aztra_bg_anim', [
+      'label' => 'Background Animation',
+      'type'  => Controls_Manager::SELECT,
+      'default' => 'none',
+      'options' => [
+        'none'      => 'None',
+        'gradient'  => 'Animated Gradient',
+        'particles' => 'Particles',
+        'noise'     => 'Noise Film',
+        'video'     => 'Video Background',
+      ],
+    ]);
+    $this->add_control('aztra_enable_overlay', [
+      'label'=>'Enable Overlay','type'=>Controls_Manager::SWITCHER,'default'=>'',
+      'description'=>'Adds a color overlay above the background animation.',
+    ]);
+    $this->add_control('aztra_overlay', [
+      'label'=>'Overlay Color',
+      'type'=>Controls_Manager::COLOR,
+      'default'=>'rgba(0,0,0,0.35)',
+    ]);
+    $this->add_control('aztra_grad_color_1', [
+      'label'=>'Gradient Color 1',
+      'type'=>Controls_Manager::COLOR,
+      'default'=>'#7c3aed','condition'=>['aztra_bg_anim'=>'gradient'],
+    ]);
+    $this->add_control('aztra_grad_color_2', [
+      'label'=>'Gradient Color 2',
+      'type'=>Controls_Manager::COLOR,
+      'default'=>'#06b6d4','condition'=>['aztra_bg_anim'=>'gradient'],
+    ]);
+    $this->add_control('aztra_grad_speed', [
+      'label'=>'Gradient Speed (s)',
+      'type'=>Controls_Manager::NUMBER,
+      'default'=>18, 'min'=>2,'max'=>60,'condition'=>['aztra_bg_anim'=>'gradient'],
+    ]);
+    $this->add_control('aztra_particles_density', [
+      'label'=>'Particles Density',
+      'type'=>Controls_Manager::SLIDER,
+      'range'=>['px'=>['min'=>20,'max'=>300]],
+      'default'=>['size'=>120],'condition'=>['aztra_bg_anim'=>'particles'],
+    ]);
+    $this->add_control('aztra_particles_speed', [
+      'label'=>'Particles Speed',
+      'type'=>Controls_Manager::SLIDER,
+      'range'=>['px'=>['min'=>0,'max'=>3,'step'=>0.1]],
+      'default'=>['size'=>0.6],'condition'=>['aztra_bg_anim'=>'particles'],
+    ]);
+    $this->add_control('aztra_noise_strength', [
+      'label'=>'Noise Strength',
+      'type'=>Controls_Manager::SLIDER,
+      'range'=>['px'=>['min'=>0,'max'=>1,'step'=>0.05]],
+      'default'=>['size'=>0.15],'condition'=>['aztra_bg_anim'=>'noise'],
+    ]);
+    $this->add_control('aztra_video_url', [
+      'label'=>'Video URL (mp4/webm)',
+      'type'=>Controls_Manager::TEXT,'label_block'=>true,'placeholder'=>'https://…/bg.mp4',
+      'condition'=>['aztra_bg_anim'=>'video'],
+    ]);
+    $this->end_controls_section();
+  }
+
+  protected function aztra_wrapper_attrs( $settings ){
+    $attrs = [
+      'class' => 'aztra-el-wrap' . ( !empty($settings['aztra_enable_overlay']) ? ' has-overlay' : '' ),
+      'style' => '--aztra-overlay: '.( $settings['aztra_overlay'] ?? 'rgba(0,0,0,0.35)' ).';',
+      'data-anim' => $settings['aztra_bg_anim'] ?? 'none',
+      'data-grad-1' => $settings['aztra_grad_color_1'] ?? '',
+      'data-grad-2' => $settings['aztra_grad_color_2'] ?? '',
+      'data-grad-speed' => $settings['aztra_grad_speed'] ?? 18,
+      'data-particles-density' => isset($settings['aztra_particles_density']['size']) ? $settings['aztra_particles_density']['size'] : 120,
+      'data-particles-speed'   => isset($settings['aztra_particles_speed']['size']) ? $settings['aztra_particles_speed']['size'] : 0.6,
+      'data-noise-strength'    => isset($settings['aztra_noise_strength']['size']) ? $settings['aztra_noise_strength']['size'] : 0.15,
+      'data-video' => $settings['aztra_video_url'] ?? '',
+    ];
+    $html = '';
+    foreach($attrs as $k=>$v){ if($v===null) $v=''; $html .= ' '.esc_attr($k).'="'.esc_attr($v).'"'; }
+    return $html;
+  }
+}


### PR DESCRIPTION
## Summary
- auto-generate Home and Chat pages with shortcodes on plugin activation
- document created pages in README and dashboard with updated shortcode list

## Testing
- `php -l aztra-g-fall-animal/includes/activator.php`
- `php -l aztra-g-fall-animal/includes/class-aztra-admin.php`
- `php -l aztra-g-fall-animal/README.md`


------
https://chatgpt.com/codex/tasks/task_e_68a1fbc462488332b146c38353c2e986