### PR TITLE
Add tutorials shortcode with tab navigation

### DIFF
--- a/aztra-g-fall-animal/README.md
+++ b/aztra-g-fall-animal/README.md
@@ -9,10 +9,11 @@ WordPress plugin providing an interface to build and chat with Animal Flight mod
 - `[aztra_login]` and `[aztra_signup]` – basic authentication pages.
 - `[aztra_privacy]` and `[aztra_terms]` – render the Privacy Policy and Terms of Use from the settings.
 - `[aztra_commands]` – placeholder page for global commands and customisation.
+- `[aztra_tutorials]` – tabs with introduction, examples and FAQ.
 
 ## Setup
 
-1. Upload the plugin to your WordPress installation and activate it. Activation creates the pages **Aztra — Home**, **Chat**, **App**, **Gallery**, **Login**, **Signup**, **Privacy Policy**, **Terms of Use** and **Commands**.
+1. Upload the plugin to your WordPress installation and activate it. Activation creates the pages **Aztra — Home**, **Chat**, **App**, **Gallery**, **Login**, **Signup**, **Privacy Policy**, **Terms of Use**, **Commands** and **Tutoriais**.
 2. On first visit, go to **Aztra — Home** to preview the webhook response.
 3. Use **Salvar Modelo e iniciar conversa** to store your production webhook and open the chat.
 

--- a/aztra-g-fall-animal/assets/app.css
+++ b/aztra-g-fall-animal/assets/app.css
@@ -39,3 +39,6 @@ body{background:var(--az-bg);color:var(--az-text);font-family:Inter,system-ui,sa
 .az-assets{display:flex;flex-wrap:wrap;gap:12px;}
 .az-thumb{max-width:100%;height:auto;border-radius:12px;border:1px solid var(--az-input-bd);box-shadow:0 4px 16px rgba(0,0,0,.25);}
 pre{background:var(--az-input-bg);color:var(--az-text);padding:12px;border-radius:10px;max-height:280px;overflow:auto;}
+.az-tabs-nav{display:flex;gap:8px;margin-bottom:var(--az-gap);}
+.az-tab{display:none;}
+.az-tab.active{display:block;}

--- a/aztra-g-fall-animal/assets/tutorials.js
+++ b/aztra-g-fall-animal/assets/tutorials.js
@@ -1,0 +1,19 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    const buttons = document.querySelectorAll('[data-aztra-tab]');
+    const tabs = document.querySelectorAll('.az-tab');
+    function show(id){
+      tabs.forEach(t=>t.classList.toggle('active', t.id===id));
+      buttons.forEach(b=>b.classList.toggle('active', b.getAttribute('data-aztra-tab')===id));
+    }
+    buttons.forEach(btn=>{
+      btn.addEventListener('click', function(){
+        show(this.getAttribute('data-aztra-tab'));
+      });
+    });
+    if(buttons.length){ show(buttons[0].getAttribute('data-aztra-tab')); }
+    document.querySelectorAll('pre code').forEach(block=>{
+      if(window.hljs){ window.hljs.highlightElement(block); }
+    });
+  });
+})();

--- a/aztra-g-fall-animal/aztra-g-fall-animal.php
+++ b/aztra-g-fall-animal/aztra-g-fall-animal.php
@@ -71,6 +71,7 @@ class AztraG_Fall_Animal_Plugin {
     wp_register_style('aztra-el', AZTRA_URL.'assets/elementor.css', [], AZTRA_VER);
     wp_register_script('aztra-app', AZTRA_URL.'assets/app.js', ['jquery'], AZTRA_VER, true);
     wp_register_script('aztra-chat', AZTRA_URL.'assets/chat.js', ['aztra-app'], AZTRA_VER, true);
+    wp_register_script('aztra-tutorials', AZTRA_URL.'assets/tutorials.js', ['aztra-app'], AZTRA_VER, true);
     wp_register_script('aztra-el', AZTRA_URL.'assets/elementor.js', [], AZTRA_VER, true);
     wp_localize_script('aztra-app','AZTRA_CFG',[
       'rest'=> esc_url_raw( rest_url('aztra/v1') ),

--- a/aztra-g-fall-animal/includes/activator.php
+++ b/aztra-g-fall-animal/includes/activator.php
@@ -32,6 +32,7 @@ class Aztra_Activator {
       'Aztra — Privacy Policy' => '[aztra_privacy]',
       'Aztra — Terms of Use'   => '[aztra_terms]',
       'Aztra — Commands'       => '[aztra_commands]',
+      'Aztra — Tutoriais'      => '[aztra_tutorials]',
     ];
     foreach($pages as $title=>$sc){
       if(!get_page_by_title($title)){

--- a/aztra-g-fall-animal/includes/class-aztra-shortcodes.php
+++ b/aztra-g-fall-animal/includes/class-aztra-shortcodes.php
@@ -12,6 +12,7 @@ class Aztra_Shortcodes {
     add_shortcode('aztra_privacy', [__CLASS__, 'privacy']);
     add_shortcode('aztra_terms', [__CLASS__, 'terms']);
     add_shortcode('aztra_commands', [__CLASS__, 'commands']);
+    add_shortcode('aztra_tutorials', [__CLASS__, 'tutorials']);
   }
 
   private static function render_header(){
@@ -19,6 +20,7 @@ class Aztra_Shortcodes {
     <header class="az-header">
       <div class="az-brand">Aztra&nbsp;G</div>
       <nav class="az-nav">
+        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Tutoriais') ) ); ?>">Tutoriais</a>
         <button class="az-btn" data-aztra-act="toggle-theme">Tema</button>
       </nav>
     </header>
@@ -229,6 +231,30 @@ class Aztra_Shortcodes {
     <div class="az-commands">
       <h2>Aztra Commands</h2>
       <p>Customize your app and functions here.</p>
+    </div>
+    <?php self::render_footer(); return ob_get_clean();
+  }
+
+  public static function tutorials($atts=[]){
+    wp_enqueue_style('aztra-app');
+    wp_enqueue_script('aztra-app');
+    wp_enqueue_script('aztra-tutorials');
+    ob_start(); self::render_header(); ?>
+    <div class="az-tutorials">
+      <nav class="az-tabs-nav">
+        <button class="az-btn" data-aztra-tab="intro"><?php echo esc_html__('Introdução','aztra'); ?></button>
+        <button class="az-btn" data-aztra-tab="examples"><?php echo esc_html__('Exemplos','aztra'); ?></button>
+        <button class="az-btn" data-aztra-tab="faq"><?php echo esc_html__('FAQ','aztra'); ?></button>
+      </nav>
+      <div id="intro" class="az-tab">
+        <p><?php echo esc_html__('Bem-vindo aos tutoriais do Aztra G.','aztra'); ?></p>
+      </div>
+      <div id="examples" class="az-tab">
+        <pre><code>echo "Aztra";</code></pre>
+      </div>
+      <div id="faq" class="az-tab">
+        <p><?php echo esc_html__('Perguntas frequentes serão adicionadas aqui.','aztra'); ?></p>
+      </div>
     </div>
     <?php self::render_footer(); return ob_get_clean();
   }


### PR DESCRIPTION
## Summary
- add tutorial shortcode and register associated script
- include tutorials page during activation and link from header
- document new `[aztra_tutorials]` shortcode in README

## Testing
- `php -l aztra-g-fall-animal/aztra-g-fall-animal.php`
- `php -l aztra-g-fall-animal/includes/activator.php`
- `php -l aztra-g-fall-animal/includes/class-aztra-shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68a226a7717c83328a25bdefadfa2a36