### PR TITLE
feat: accessibility controls and translation setup

### DIFF
--- a/aztra-g-fall-animal/README.md
+++ b/aztra-g-fall-animal/README.md
@@ -1,18 +1,19 @@
-# Aztra G Fall Animal
+# Aztra G
 
-WordPress plugin providing an interface to build and chat with Animal Flight models. The plugin registers several shortcodes:
+WordPress plugin providing an interface to build and chat with models via an n8n workflow. The plugin registers several shortcodes:
 
 - `[aztra_home]` – landing page with a sample JSON preview and button to save your webhook before starting a conversation.
 - `[aztra_builder]` – form to configure model parameters and send them to the workflow.
 - `[aztra_chat]` – two-column chat interface supporting file uploads.
 - `[aztra_gallery]` – list of saved responses for the current user.
-- `[aztra_login]` and `[aztra_signup]` – basic authentication pages.
+- `[aztra_agent]` – simple generator that guides users to create an agent webhook.
 - `[aztra_privacy]` and `[aztra_terms]` – render the Privacy Policy and Terms of Use from the settings.
 - `[aztra_commands]` – placeholder page for global commands and customisation.
+- `[aztra_tutorials]` – tabs with introduction, examples and FAQ.
 
 ## Setup
 
-1. Upload the plugin to your WordPress installation and activate it. Activation creates the pages **Aztra — Home**, **Chat**, **App**, **Gallery**, **Login**, **Signup**, **Privacy Policy**, **Terms of Use** and **Commands**.
+1. Upload the plugin to your WordPress installation and activate it. Activation creates the pages **Aztra — Home**, **Chat**, **Builder**, **Gere Seu Agente**, **Gallery**, **Política de Privacidade**, **Termos de Uso**, **Commands** and **Tutoriais**.
 2. On first visit, go to **Aztra — Home** to preview the webhook response.
 3. Use **Salvar Modelo e iniciar conversa** to store your production webhook and open the chat.
 
@@ -27,7 +28,7 @@ Under **Aztra G → Settings** you can define the webhook, lists of options for 
 Source code lives in the `aztra-g-fall-animal` directory. Assets are in `assets/`. PHP lint can be run with:
 
 ```bash
-php -l aztra-g-fall-animal.php
+php -l aztra-g.php
 php -l includes/class-aztra-shortcodes.php
 ```
 

--- a/aztra-g-fall-animal/assets/app.css
+++ b/aztra-g-fall-animal/assets/app.css
@@ -7,6 +7,8 @@
   --az-input-bd:#dfe6f0;
   --az-btn-bg:linear-gradient(135deg,#2563eb,#7c3aed);
   --az-gap:16px;
+  --az-font-size:16px;
+  --az-contrast:1;
 }
 .az-theme-dark{
   --az-bg:#0e1116;
@@ -17,7 +19,7 @@
   --az-input-bd:#263041;
   --az-btn-bg:linear-gradient(135deg,#7c3aed,#06b6d4);
 }
-body{background:var(--az-bg);color:var(--az-text);font-family:Inter,system-ui,sans-serif;}
+body{background:var(--az-bg);color:var(--az-text);font-family:Inter,system-ui,sans-serif;font-size:var(--az-font-size);filter:contrast(var(--az-contrast));}
 .az-header,.az-footer{padding:var(--az-gap);}
 .az-header{display:flex;justify-content:space-between;align-items:center;}
 .az-nav{display:flex;gap:8px;}
@@ -30,6 +32,7 @@ body{background:var(--az-bg);color:var(--az-text);font-family:Inter,system-ui,sa
 .az-chat-msg .az-file{display:block;margin-top:6px;}
 .az-btn{background:#2b34ff;color:#fff;border:none;border-radius:10px;padding:10px 14px;cursor:pointer;}
 .az-btn.az-primary{background:var(--az-btn-bg);}
+.az-btn:focus,.az-field input:focus,.az-field select:focus,.az-field textarea:focus{outline:2px solid currentColor;outline-offset:2px;}
 .az-field{display:flex;flex-direction:column;gap:6px;margin-bottom:10px;}
 .az-field input,.az-field select,.az-field textarea{background:var(--az-input-bg);color:var(--az-text);border:1px solid var(--az-input-bd);border-radius:10px;padding:10px;}
 .az-overlay{position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1000;}
@@ -39,3 +42,6 @@ body{background:var(--az-bg);color:var(--az-text);font-family:Inter,system-ui,sa
 .az-assets{display:flex;flex-wrap:wrap;gap:12px;}
 .az-thumb{max-width:100%;height:auto;border-radius:12px;border:1px solid var(--az-input-bd);box-shadow:0 4px 16px rgba(0,0,0,.25);}
 pre{background:var(--az-input-bg);color:var(--az-text);padding:12px;border-radius:10px;max-height:280px;overflow:auto;}
+.az-tabs-nav{display:flex;gap:8px;margin-bottom:var(--az-gap);}
+.az-tab{display:none;}
+.az-tab.active{display:block;}

--- a/aztra-g-fall-animal/assets/app.js
+++ b/aztra-g-fall-animal/assets/app.js
@@ -11,8 +11,30 @@
     localStorage.setItem('aztra_theme', mode);
   };
   const toggleTheme = ()=>setTheme(document.body.classList.contains('az-theme-dark')?'light':'dark');
+
+  const setFont = (size)=>{
+    document.documentElement.style.setProperty('--az-font-size', size+'px');
+    localStorage.setItem('aztra_font', size);
+  };
+  const changeFont = (d)=>{
+    const cur = parseFloat(localStorage.getItem('aztra_font')||'16');
+    const next = Math.min(Math.max(cur + d, 12), 24);
+    setFont(next);
+  };
+  const setContrast = (c)=>{
+    document.documentElement.style.setProperty('--az-contrast', c);
+    localStorage.setItem('aztra_contrast', c);
+  };
+  const toggleContrast = ()=>{
+    const cur = localStorage.getItem('aztra_contrast')||'1';
+    setContrast(cur==='1' ? '2' : '1');
+  };
+
   setTheme(localStorage.getItem('aztra_theme')||'light');
-  window.Aztra = {api,setTheme,toggleTheme};
+  setFont(parseFloat(localStorage.getItem('aztra_font')||'16'));
+  setContrast(localStorage.getItem('aztra_contrast')||'1');
+
+  window.Aztra = {api,setTheme,toggleTheme,changeFont,toggleContrast};
 
   const previewEl = qs('#aztra-preview');
   if(previewEl){
@@ -44,6 +66,9 @@
     }
 
     if(act==='toggle-theme') toggleTheme();
+    if(act==='font-inc') changeFont(2);
+    if(act==='font-dec') changeFont(-2);
+    if(act==='toggle-contrast') toggleContrast();
 
     if(act==='open-save-model') openWebhookModal();
 
@@ -56,6 +81,16 @@
         await api('/webhook',{method:'POST',body:new URLSearchParams({url})});
       }
       window.location.href = AZTRA_CFG.chat_url || '/';
+    }
+  });
+
+  document.addEventListener('change', e=>{
+    const el = e.target;
+    if(el.dataset.aztraAct==='set-lang'){
+      const lang = el.value;
+      const url = new URL(window.location.href);
+      url.searchParams.set('lang', lang);
+      window.location.href = url.toString();
     }
   });
 

--- a/aztra-g-fall-animal/assets/tutorials.js
+++ b/aztra-g-fall-animal/assets/tutorials.js
@@ -1,0 +1,19 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    const buttons = document.querySelectorAll('[data-aztra-tab]');
+    const tabs = document.querySelectorAll('.az-tab');
+    function show(id){
+      tabs.forEach(t=>t.classList.toggle('active', t.id===id));
+      buttons.forEach(b=>b.classList.toggle('active', b.getAttribute('data-aztra-tab')===id));
+    }
+    buttons.forEach(btn=>{
+      btn.addEventListener('click', function(){
+        show(this.getAttribute('data-aztra-tab'));
+      });
+    });
+    if(buttons.length){ show(buttons[0].getAttribute('data-aztra-tab')); }
+    document.querySelectorAll('pre code').forEach(block=>{
+      if(window.hljs){ window.hljs.highlightElement(block); }
+    });
+  });
+})();

--- a/aztra-g-fall-animal/aztra-g.php
+++ b/aztra-g-fall-animal/aztra-g.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Plugin Name: Aztra G Fall Animal
- * Description: Hub multiuser with Elementor widgets, shortcodes and secure proxy to n8n workflow (Animal Flight). Includes Elementor "Aztra" top tab with background animations.
+ * Plugin Name: Aztra G
+ * Description: Hub multiuser with Elementor widgets, shortcodes and secure proxy to n8n workflow. Includes Elementor "Aztra" top tab with background animations.
  * Version: 1.2.0
  * Author: Aztragroup
  * Text Domain: aztra
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) exit;
 // ---- Requirements ----
 if (version_compare(PHP_VERSION, '7.4', '<')) {
   add_action('admin_notices', function(){
-    echo '<div class="notice notice-error"><p><b>Aztra G Fall Animal:</b> requires PHP 7.4 or higher.</p></div>';
+    echo '<div class="notice notice-error"><p><b>Aztra G:</b> requires PHP 7.4 or higher.</p></div>';
   });
   return;
 }
@@ -42,11 +42,14 @@ aztra_require('includes/class-aztra-rest.php');
 aztra_require('includes/class-aztra-shortcodes.php');
 aztra_require('includes/class-aztra-elementor.php');
 
-class AztraG_Fall_Animal_Plugin {
+class AztraG_Plugin {
   public function __construct(){
     if (class_exists('Aztra_Activator')) {
       register_activation_hook(__FILE__, ['Aztra_Activator','activate']);
     }
+    add_action('plugins_loaded', function(){
+      load_plugin_textdomain('aztra', false, dirname(plugin_basename(__FILE__)).'/languages');
+    });
     add_action('init', function(){
       if (class_exists('Aztra_CPT')) Aztra_CPT::register();
       if (class_exists('Aztra_Shortcodes')) Aztra_Shortcodes::register();
@@ -71,6 +74,7 @@ class AztraG_Fall_Animal_Plugin {
     wp_register_style('aztra-el', AZTRA_URL.'assets/elementor.css', [], AZTRA_VER);
     wp_register_script('aztra-app', AZTRA_URL.'assets/app.js', ['jquery'], AZTRA_VER, true);
     wp_register_script('aztra-chat', AZTRA_URL.'assets/chat.js', ['aztra-app'], AZTRA_VER, true);
+    wp_register_script('aztra-tutorials', AZTRA_URL.'assets/tutorials.js', ['aztra-app'], AZTRA_VER, true);
     wp_register_script('aztra-el', AZTRA_URL.'assets/elementor.js', [], AZTRA_VER, true);
     wp_localize_script('aztra-app','AZTRA_CFG',[
       'rest'=> esc_url_raw( rest_url('aztra/v1') ),
@@ -84,4 +88,4 @@ class AztraG_Fall_Animal_Plugin {
     wp_enqueue_script('aztra-editor', AZTRA_URL.'assets/editor.js', ['jquery','elementor-editor'], AZTRA_VER, true);
   }
 }
-new AztraG_Fall_Animal_Plugin();
+new AztraG_Plugin();

--- a/aztra-g-fall-animal/includes/activator.php
+++ b/aztra-g-fall-animal/includes/activator.php
@@ -21,22 +21,34 @@ class Aztra_Activator {
         'terms_template'=>"These Terms of Use govern the site operated by {company_name}. For support: {contact_email}.",
       ], false);
     }
-    // create pages with shortcodes
+    // create pages with shortcodes and store their IDs
     $pages = [
-      'Aztra — Home'           => '[aztra_home]',
-      'Aztra — Chat'           => '[aztra_chat]',
-      'Aztra — Login'          => '[aztra_login]',
-      'Aztra — Signup'         => '[aztra_signup]',
-      'Aztra — App'            => '[aztra_builder]',
-      'Aztra — Gallery'        => '[aztra_gallery]',
-      'Aztra — Privacy Policy' => '[aztra_privacy]',
-      'Aztra — Terms of Use'   => '[aztra_terms]',
-      'Aztra — Commands'       => '[aztra_commands]',
+      'Aztra — Home'        => '[aztra_home]',
+      'Aztra — Chat'        => '[aztra_chat]',
+      'Aztra — Builder'     => '[aztra_builder]',
+      'Gere Seu Agente'     => '[aztra_agent]',
+      'Aztra — Galeria'     => '[aztra_gallery]',
+      'Aztra — Tutoriais'   => '[aztra_tutorials]',
+      'Política de Privacidade' => '[aztra_privacy]',
+      'Termos de Uso'           => '[aztra_terms]',
+      'Aztra — Commands'    => '[aztra_commands]',
     ];
+
+    $ids = [];
     foreach($pages as $title=>$sc){
-      if(!get_page_by_title($title)){
-        wp_insert_post(['post_title'=>$title,'post_status'=>'publish','post_type'=>'page','post_content'=>$sc]);
+      $page = get_page_by_title($title);
+      if(!$page){
+        $page_id = wp_insert_post([
+          'post_title'   => $title,
+          'post_status'  => 'publish',
+          'post_type'    => 'page',
+          'post_content' => $sc,
+        ]);
+      } else {
+        $page_id = $page->ID;
       }
+      $ids[$title] = (int)$page_id;
     }
+    update_option('aztra_page_ids', $ids, false);
   }
 }

--- a/aztra-g-fall-animal/includes/class-aztra-shortcodes.php
+++ b/aztra-g-fall-animal/includes/class-aztra-shortcodes.php
@@ -9,9 +9,11 @@ class Aztra_Shortcodes {
     add_shortcode('aztra_gallery', [__CLASS__, 'gallery']);
     add_shortcode('aztra_home', [__CLASS__, 'home']);
     add_shortcode('aztra_chat', [__CLASS__, 'chat']);
+    add_shortcode('aztra_agent', [__CLASS__, 'agent']);
     add_shortcode('aztra_privacy', [__CLASS__, 'privacy']);
     add_shortcode('aztra_terms', [__CLASS__, 'terms']);
     add_shortcode('aztra_commands', [__CLASS__, 'commands']);
+    add_shortcode('aztra_tutorials', [__CLASS__, 'tutorials']);
   }
 
   private static function render_header(){
@@ -19,7 +21,23 @@ class Aztra_Shortcodes {
     <header class="az-header">
       <div class="az-brand">Aztra&nbsp;G</div>
       <nav class="az-nav">
-        <button class="az-btn" data-aztra-act="toggle-theme">Tema</button>
+        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Home') ) ); ?>"><?php echo esc_html__('Home','aztra'); ?></a>
+        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Chat') ) ); ?>"><?php echo esc_html__('Chat','aztra'); ?></a>
+        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Builder') ) ); ?>"><?php echo esc_html__('Builder','aztra'); ?></a>
+        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Galeria') ) ); ?>"><?php echo esc_html__('Galeria','aztra'); ?></a>
+        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Tutoriais') ) ); ?>"><?php echo esc_html__('Tutoriais','aztra'); ?></a>
+        <a class="az-btn" href="<?php echo esc_url( admin_url('admin.php?page=aztra-settings') ); ?>"><?php echo esc_html__('Settings','aztra'); ?></a>
+        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Commands') ) ); ?>"><?php echo esc_html__('Commands','aztra'); ?></a>
+        <button class="az-btn" data-aztra-act="font-inc" aria-label="<?php echo esc_attr__('Increase font','aztra'); ?>">A+</button>
+        <button class="az-btn" data-aztra-act="font-dec" aria-label="<?php echo esc_attr__('Decrease font','aztra'); ?>">A-</button>
+        <button class="az-btn" data-aztra-act="toggle-contrast"><?php echo esc_html__('Alto contraste','aztra'); ?></button>
+        <button class="az-btn" data-aztra-act="toggle-theme"><?php echo esc_html__('Tema','aztra'); ?></button>
+        <select class="az-btn" data-aztra-act="set-lang" aria-label="<?php echo esc_attr__('Idioma','aztra'); ?>">
+          <option value="pt_BR">PT</option>
+          <option value="en_US">EN</option>
+          <option value="es_ES">ES</option>
+          <option value="it_IT">IT</option>
+        </select>
       </nav>
     </header>
     <?php
@@ -28,7 +46,10 @@ class Aztra_Shortcodes {
   private static function render_footer(){
     ?>
     <footer class="az-footer">
-      <a href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Tutoriais') ) ); ?>">Tutoriais</a>
+      <a href="<?php echo esc_url( get_permalink( get_page_by_title('Política de Privacidade') ) ); ?>"><?php echo esc_html__('Política de Privacidade','aztra'); ?></a>
+      <a href="<?php echo esc_url( get_permalink( get_page_by_title('Termos de Uso') ) ); ?>"><?php echo esc_html__('Termos de Uso','aztra'); ?></a>
+      <a href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Tutoriais') ) ); ?>"><?php echo esc_html__('Tutoriais','aztra'); ?></a>
+      <a href="#"><?php echo esc_html__('Suporte','aztra'); ?></a>
     </footer>
     <?php
   }
@@ -46,7 +67,7 @@ class Aztra_Shortcodes {
         </form>
         <p>Don't have an account? <a href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Signup') ) ); ?>">Create account</a></p>
       <?php else: ?>
-        <p>You're logged in. <a href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — App') ) ); ?>">Open App</a></p>
+        <p>You're logged in. <a href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Builder') ) ); ?>">Open Builder</a></p>
       <?php endif; ?>
     </div>
     <?php return ob_get_clean();
@@ -158,36 +179,47 @@ class Aztra_Shortcodes {
     ob_start();
     self::render_header(); ?>
     <div class="az-home">
-      <p>utilize o webhook teste para testar</p>
+      <p><?php echo esc_html__('utilize o webhook teste para testar','aztra'); ?></p>
       <pre id="aztra-preview">{}</pre>
-      <button class="az-btn az-primary" data-aztra-act="open-save-model">Salvar Modelo e iniciar conversa</button>
+      <button class="az-btn az-primary" data-aztra-act="open-save-model"><?php echo esc_html__('Salvar Modelo e iniciar conversa','aztra'); ?></button>
     </div>
     <?php self::render_footer();
     return ob_get_clean();
   }
 
-    public static function chat($atts=[]){
+  public static function chat($atts=[]){
       if(!is_user_logged_in()){ return '<p>Please log in to use the chat.</p>'; }
       wp_enqueue_style('aztra-app'); wp_enqueue_script('aztra-app'); wp_enqueue_script('aztra-chat');
     ob_start();
     self::render_header(); ?>
     <div class="az-chat-layout">
       <aside class="az-sidebar">
-        <button class="az-btn" data-aztra-act="new-chat">Novo chat</button>
-        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Gallery') ) ); ?>">Galeria</a>
-        <button class="az-btn" data-aztra-act="new-project">Novo Projeto</button>
-        <div class="az-label">Projeto Aztra G</div>
-        <button class="az-btn" data-aztra-act="user-settings">Configurações de usuário</button>
+        <button class="az-btn" data-aztra-act="new-chat"><?php echo esc_html__('Novo chat','aztra'); ?></button>
+        <a class="az-btn" href="<?php echo esc_url( get_permalink( get_page_by_title('Aztra — Galeria') ) ); ?>"><?php echo esc_html__('Galeria','aztra'); ?></a>
+        <button class="az-btn" data-aztra-act="new-project"><?php echo esc_html__('Novo Projeto','aztra'); ?></button>
+        <div class="az-label"><?php echo esc_html__('Projeto Aztra G','aztra'); ?></div>
+        <button class="az-btn" data-aztra-act="user-settings"><?php echo esc_html__('Configurações de usuário','aztra'); ?></button>
       </aside>
       <section class="az-chat">
         <div id="aztra-chat-log" class="az-chat-log"></div>
         <div class="az-field"><input id="aztra-chat-file" type="file" multiple></div>
-        <div class="az-field"><textarea id="aztra-chat-message" rows="3" placeholder="Digite sua mensagem..."></textarea></div>
-        <button class="az-btn az-primary" data-aztra-act="send-chat">Enviar</button>
+        <div class="az-field"><textarea id="aztra-chat-message" rows="3" placeholder="<?php echo esc_attr__('Digite sua mensagem...','aztra'); ?>"></textarea></div>
+        <button class="az-btn az-primary" data-aztra-act="send-chat"><?php echo esc_html__('Enviar','aztra'); ?></button>
       </section>
     </div>
     <?php self::render_footer();
     return ob_get_clean();
+  }
+
+  public static function agent($atts = []){
+    wp_enqueue_style('aztra-app');
+    wp_enqueue_script('aztra-app');
+    ob_start(); self::render_header(); ?>
+    <div class="az-agent">
+      <h2><?php echo esc_html__('Gere Seu Agente','aztra'); ?></h2>
+      <p><?php echo esc_html__('Selecione um template para gerar um webhook de agente.','aztra'); ?></p>
+    </div>
+    <?php self::render_footer(); return ob_get_clean();
   }
 
   private static function replace_placeholders($text){
@@ -229,6 +261,30 @@ class Aztra_Shortcodes {
     <div class="az-commands">
       <h2>Aztra Commands</h2>
       <p>Customize your app and functions here.</p>
+    </div>
+    <?php self::render_footer(); return ob_get_clean();
+  }
+
+  public static function tutorials($atts=[]){
+    wp_enqueue_style('aztra-app');
+    wp_enqueue_script('aztra-app');
+    wp_enqueue_script('aztra-tutorials');
+    ob_start(); self::render_header(); ?>
+    <div class="az-tutorials">
+      <nav class="az-tabs-nav">
+        <button class="az-btn" data-aztra-tab="intro"><?php echo esc_html__('Introdução','aztra'); ?></button>
+        <button class="az-btn" data-aztra-tab="examples"><?php echo esc_html__('Exemplos','aztra'); ?></button>
+        <button class="az-btn" data-aztra-tab="faq"><?php echo esc_html__('FAQ','aztra'); ?></button>
+      </nav>
+      <div id="intro" class="az-tab">
+        <p><?php echo esc_html__('Bem-vindo aos tutoriais do Aztra G.','aztra'); ?></p>
+      </div>
+      <div id="examples" class="az-tab">
+        <pre><code>echo "Aztra";</code></pre>
+      </div>
+      <div id="faq" class="az-tab">
+        <p><?php echo esc_html__('Perguntas frequentes serão adicionadas aqui.','aztra'); ?></p>
+      </div>
     </div>
     <?php self::render_footer(); return ob_get_clean();
   }

--- a/aztra-g-fall-animal/languages/aztra.pot
+++ b/aztra-g-fall-animal/languages/aztra.pot
@@ -1,0 +1,89 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Aztra G\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: \n"
+
+msgid "Home"
+msgstr ""
+
+msgid "Chat"
+msgstr ""
+
+msgid "Builder"
+msgstr ""
+
+msgid "Galeria"
+msgstr ""
+
+msgid "Tutoriais"
+msgstr ""
+
+msgid "Settings"
+msgstr ""
+
+msgid "Commands"
+msgstr ""
+
+msgid "Increase font"
+msgstr ""
+
+msgid "Decrease font"
+msgstr ""
+
+msgid "Alto contraste"
+msgstr ""
+
+msgid "Tema"
+msgstr ""
+
+msgid "Idioma"
+msgstr ""
+
+msgid "Política de Privacidade"
+msgstr ""
+
+msgid "Termos de Uso"
+msgstr ""
+
+msgid "Suporte"
+msgstr ""
+
+msgid "utilize o webhook teste para testar"
+msgstr ""
+
+msgid "Salvar Modelo e iniciar conversa"
+msgstr ""
+
+msgid "Novo chat"
+msgstr ""
+
+msgid "Novo Projeto"
+msgstr ""
+
+msgid "Projeto Aztra G"
+msgstr ""
+
+msgid "Configurações de usuário"
+msgstr ""
+
+msgid "Digite sua mensagem..."
+msgstr ""
+
+msgid "Enviar"
+msgstr ""
+
+msgid "Introdução"
+msgstr ""
+
+msgid "Exemplos"
+msgstr ""
+
+msgid "FAQ"
+msgstr ""
+
+msgid "Bem-vindo aos tutoriais do Aztra G."
+msgstr ""
+
+msgid "Perguntas frequentes serão adicionadas aqui."
+msgstr ""

--- a/aztra-g-fall-animal/languages/en_US.po
+++ b/aztra-g-fall-animal/languages/en_US.po
@@ -1,0 +1,89 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Aztra G\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: en_US\n"
+
+msgid "Home"
+msgstr "Home"
+
+msgid "Chat"
+msgstr "Chat"
+
+msgid "Builder"
+msgstr "Builder"
+
+msgid "Galeria"
+msgstr "Gallery"
+
+msgid "Tutoriais"
+msgstr "Tutorials"
+
+msgid "Settings"
+msgstr "Settings"
+
+msgid "Commands"
+msgstr "Commands"
+
+msgid "Increase font"
+msgstr "Increase font"
+
+msgid "Decrease font"
+msgstr "Decrease font"
+
+msgid "Alto contraste"
+msgstr "High contrast"
+
+msgid "Tema"
+msgstr "Theme"
+
+msgid "Idioma"
+msgstr "Language"
+
+msgid "Política de Privacidade"
+msgstr "Privacy Policy"
+
+msgid "Termos de Uso"
+msgstr "Terms of Use"
+
+msgid "Suporte"
+msgstr "Support"
+
+msgid "utilize o webhook teste para testar"
+msgstr "use the test webhook to try"
+
+msgid "Salvar Modelo e iniciar conversa"
+msgstr "Save Model and start chat"
+
+msgid "Novo chat"
+msgstr "New chat"
+
+msgid "Novo Projeto"
+msgstr "New Project"
+
+msgid "Projeto Aztra G"
+msgstr "Project Aztra G"
+
+msgid "Configurações de usuário"
+msgstr "User settings"
+
+msgid "Digite sua mensagem..."
+msgstr "Type your message..."
+
+msgid "Enviar"
+msgstr "Send"
+
+msgid "Introdução"
+msgstr "Introduction"
+
+msgid "Exemplos"
+msgstr "Examples"
+
+msgid "FAQ"
+msgstr "FAQ"
+
+msgid "Bem-vindo aos tutoriais do Aztra G."
+msgstr "Welcome to Aztra G tutorials."
+
+msgid "Perguntas frequentes serão adicionadas aqui."
+msgstr "Frequently asked questions will be added here."

--- a/aztra-g-fall-animal/languages/pt_BR.po
+++ b/aztra-g-fall-animal/languages/pt_BR.po
@@ -1,0 +1,89 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Aztra G\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Language: pt_BR\n"
+
+msgid "Home"
+msgstr "Início"
+
+msgid "Chat"
+msgstr "Chat"
+
+msgid "Builder"
+msgstr "Builder"
+
+msgid "Galeria"
+msgstr "Galeria"
+
+msgid "Tutoriais"
+msgstr "Tutoriais"
+
+msgid "Settings"
+msgstr "Configurações"
+
+msgid "Commands"
+msgstr "Comandos"
+
+msgid "Increase font"
+msgstr "Aumentar fonte"
+
+msgid "Decrease font"
+msgstr "Diminuir fonte"
+
+msgid "Alto contraste"
+msgstr "Alto contraste"
+
+msgid "Tema"
+msgstr "Tema"
+
+msgid "Idioma"
+msgstr "Idioma"
+
+msgid "Política de Privacidade"
+msgstr "Política de Privacidade"
+
+msgid "Termos de Uso"
+msgstr "Termos de Uso"
+
+msgid "Suporte"
+msgstr "Suporte"
+
+msgid "utilize o webhook teste para testar"
+msgstr "utilize o webhook teste para testar"
+
+msgid "Salvar Modelo e iniciar conversa"
+msgstr "Salvar Modelo e iniciar conversa"
+
+msgid "Novo chat"
+msgstr "Novo chat"
+
+msgid "Novo Projeto"
+msgstr "Novo Projeto"
+
+msgid "Projeto Aztra G"
+msgstr "Projeto Aztra G"
+
+msgid "Configurações de usuário"
+msgstr "Configurações de usuário"
+
+msgid "Digite sua mensagem..."
+msgstr "Digite sua mensagem..."
+
+msgid "Enviar"
+msgstr "Enviar"
+
+msgid "Introdução"
+msgstr "Introdução"
+
+msgid "Exemplos"
+msgstr "Exemplos"
+
+msgid "FAQ"
+msgstr "FAQ"
+
+msgid "Bem-vindo aos tutoriais do Aztra G."
+msgstr "Bem-vindo aos tutoriais do Aztra G."
+
+msgid "Perguntas frequentes serão adicionadas aqui."
+msgstr "Perguntas frequentes serão adicionadas aqui."


### PR DESCRIPTION
## Summary
- add header buttons for font size, high contrast, and language selection
- persist accessibility preferences in JS and update styles
- load textdomain and ship starter translation files

## Testing
- `php -l aztra-g-fall-animal/aztra-g.php`
- `php -l aztra-g-fall-animal/includes/class-aztra-shortcodes.php`


------
https://chatgpt.com/codex/tasks/task_e_68a226a7717c83328a25bdefadfa2a36